### PR TITLE
Improve error handling for failed requests

### DIFF
--- a/ecom_scraper/scraper.py
+++ b/ecom_scraper/scraper.py
@@ -37,7 +37,11 @@ def main():
     scraper = StaticScraper(url, output_dir, fetcher=fetcher)
 
     products_info = []
-    products = scraper.scrape_collection()
+    try:
+        products = scraper.scrape_collection()
+    except RuntimeError as exc:
+        print(f"Failed to scrape collection: {exc}")
+        return
     print(f"Found {len(products)} products")
     for p in products:
         info = scraper.scrape_product(p['link'])

--- a/ecom_scraper/utils/static_scraper.py
+++ b/ecom_scraper/utils/static_scraper.py
@@ -1,6 +1,7 @@
 import os
 import re
 import requests
+from requests import exceptions as req_exc
 from urllib.parse import urljoin
 from bs4 import BeautifulSoup
 from tqdm import tqdm
@@ -28,12 +29,16 @@ class StaticScraper:
 
     def get_soup(self, url: str) -> BeautifulSoup:
         """Return a BeautifulSoup object for the given URL."""
-        if self.fetcher:
-            html = self.fetcher(url)
-        else:
-            resp = self.session.get(url, timeout=10)
-            resp.raise_for_status()
-            html = resp.text
+        try:
+            if self.fetcher:
+                html = self.fetcher(url)
+            else:
+                resp = self.session.get(url, timeout=10)
+                resp.raise_for_status()
+                html = resp.text
+        except req_exc.RequestException as exc:
+            raise RuntimeError(f"Error fetching {url}: {exc}") from exc
+
         return BeautifulSoup(html, "html.parser")
 
     def scrape_collection(self) -> list:

--- a/tests/test_static_scraper.py
+++ b/tests/test_static_scraper.py
@@ -1,0 +1,17 @@
+import os
+import sys
+import pytest
+import requests_mock
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+from ecom_scraper.utils.static_scraper import StaticScraper
+
+
+def test_get_soup_http_error():
+    url = 'https://example.com/notfound'
+    scraper = StaticScraper(url, output_dir='outputs')
+    with requests_mock.Mocker() as m:
+        m.get(url, status_code=404)
+        with pytest.raises(RuntimeError):
+            scraper.get_soup(url)


### PR DESCRIPTION
## Summary
- handle `requests` errors in `StaticScraper.get_soup`
- show a clear message in CLI when scraping fails
- test that a 404 response raises `RuntimeError`

## Testing
- `pip install -r requirements.txt`
- `pip install pytest requests_mock`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68486e1b84988330833a3c7d746a5430